### PR TITLE
remove web page preview

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -15,7 +15,7 @@ pub mod stats;
 use derive_more::Constructor;
 use rust_i18n::t;
 use teloxide::Bot;
-use teloxide::payloads::{AnswerCallbackQuerySetters, SendMessage};
+use teloxide::payloads::{AnswerCallbackQuerySetters, SendMessage, SendMessageSetters};
 use teloxide::requests::{JsonRequest, Requester};
 use teloxide::sugar::request::RequestLinkPreviewExt;
 use teloxide::types::{CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message, ReplyParameters};
@@ -116,7 +116,9 @@ impl <D: CallbackDataWithPrefix> HandlerImplResult<D> {
 
 pub fn reply_html<T: Into<String>>(bot: Bot, msg: &Message, answer: T) -> JsonRequest<SendMessage> {
     // TODO: split to several messages if the answer is too long
-    let mut answer = bot.send_message(msg.chat.id, answer).disable_link_preview(true);
+    let mut answer = bot.send_message(msg.chat.id, answer)
+        .parse_mode(Html)
+        .disable_link_preview(true);
     answer.parse_mode = Some(Html);
     if msg.chat.is_group() || msg.chat.is_supergroup() {
         answer.reply_parameters.replace(ReplyParameters::new(msg.id));

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -17,6 +17,7 @@ use rust_i18n::t;
 use teloxide::Bot;
 use teloxide::payloads::{AnswerCallbackQuerySetters, SendMessage};
 use teloxide::requests::{JsonRequest, Requester};
+use teloxide::sugar::request::RequestLinkPreviewExt;
 use teloxide::types::{CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message, ReplyParameters};
 use teloxide::types::ParseMode::Html;
 
@@ -115,7 +116,7 @@ impl <D: CallbackDataWithPrefix> HandlerImplResult<D> {
 
 pub fn reply_html<T: Into<String>>(bot: Bot, msg: &Message, answer: T) -> JsonRequest<SendMessage> {
     // TODO: split to several messages if the answer is too long
-    let mut answer = bot.send_message(msg.chat.id, answer);
+    let mut answer = bot.send_message(msg.chat.id, answer).disable_link_preview(true);
     answer.parse_mode = Some(Html);
     if msg.chat.is_group() || msg.chat.is_supergroup() {
         answer.reply_parameters.replace(ReplyParameters::new(msg.id));

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -119,7 +119,6 @@ pub fn reply_html<T: Into<String>>(bot: Bot, msg: &Message, answer: T) -> JsonRe
     let mut answer = bot.send_message(msg.chat.id, answer)
         .parse_mode(Html)
         .disable_link_preview(true);
-    answer.parse_mode = Some(Html);
     if msg.chat.is_group() || msg.chat.is_supergroup() {
         answer.reply_parameters.replace(ReplyParameters::new(msg.id));
     }


### PR DESCRIPTION
# Problem
Some user names contain URLs (e.g., "example.com Smith"). When these names are included in messages sent via send_message, such as in the output of the /top command, Telegram automatically generates a link web preview for the URL in the name. This is unintended behavior and can be disruptive or confusing for users.

# Solution
This pull request addresses the issue by disabling the automatic link web preview feature for messages sent using the relevant send_message function call. This is achieved by setting the disable_web_page_preview parameter to true.
```rust
let mut answer = bot.send_message(msg.chat.id, answer).disable_link_preview(true);
```

![CleanShot 2025-04-24 at 18 25 04](https://github.com/user-attachments/assets/fd5bb9ba-024f-4623-8e25-9999840ff390)


