### PR TITLE
Add MAU badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [@DickGrowerBot](https://t.me/DickGrowerBot)
 ============================================
 
-[![CI Build](https://github.com/kozalosev/DickGrowerBot/actions/workflows/ci-build.yaml/badge.svg?branch=main&event=push)](https://github.com/kozalosev/DickGrowerBot/actions/workflows/ci-build.yaml)
+[![CI Build](https://github.com/kozalosev/DickGrowerBot/actions/workflows/ci-build.yaml/badge.svg?branch=main&event=push)](https://github.com/kozalosev/DickGrowerBot/actions/workflows/ci-build.yaml) [![@DickGrowerBot MAU](https://tgbotmau.quoi.dev/api/bot/DickGrowerBot/mau/badge?style=flat "@DickGrowerBot MAU")](https://tgbotmau.quoi.dev/?bot=DickGrowerBot)
 
 A game bot for group chats that let its users grow their virtual "dicks" every day for some random count of centimeters (including negative values) and compete with friends and other chat members.
 


### PR DESCRIPTION
I believe it's nice to have MAU badge in popular OpenSource bot projects to flex about huge user base.
I discovered that there're no ready to use Telegram-counted (the only real source of truth) MAU badge generators, so I've created my own small service.
In the future, I'm going to add more features to it - track MAU history over time and display a plot.

I've used badge style that fits your existing CI badge in README, but you can customize badge style on your own using https://tgbotmau.quoi.dev/.

Feel free to reach me out in case of need of any adjustments.